### PR TITLE
build: update python version and commands to use python3

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python -m gunicorn --chdir src/furigana-api --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app
+web: python3 -m gunicorn --chdir src/furigana-api --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,11 +1,15 @@
 [phases.setup]
-aptPkgs = ["tesseract-ocr", "tesseract-ocr-jpn", "poppler-utils"]
+aptPkgs = ["tesseract-ocr", "tesseract-ocr-jpn", "poppler-utils", "python3-pip", "python3-dev"]
+nixPkgs = ["python311", "python311Packages.pip"]
 
 [phases.install]
-cmds = ["pip install -r src/furigana-api/requirements.txt"]
+cmds = [
+    "python3 -m pip install --upgrade pip",
+    "python3 -m pip install -r src/furigana-api/requirements.txt"
+]
 
 [start]
-cmd = "python -m gunicorn --chdir src/furigana-api --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app"
+cmd = "python3 -m gunicorn --chdir src/furigana-api --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app"
 
 [variables]
 PYTHON_VERSION = "3.11"

--- a/railway.json
+++ b/railway.json
@@ -1,10 +1,11 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
-    "builder": "NIXPACKS"
+    "builder": "NIXPACKS",
+    "buildCommand": "python3 -m pip install --upgrade pip && python3 -m pip install -r src/furigana-api/requirements.txt"
   },
   "deploy": {
-    "startCommand": "python -m gunicorn --chdir src/furigana-api --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app",
+    "startCommand": "python3 -m gunicorn --chdir src/furigana-api --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",

--- a/railway.toml
+++ b/railway.toml
@@ -1,9 +1,10 @@
 # Configuración simplificada para Railway - Python nativo
 [build]
 builder = "NIXPACKS"
+buildCommand = "python3 -m pip install --upgrade pip && python3 -m pip install -r src/furigana-api/requirements.txt"
 
 [deploy]
-startCommand = "python -m gunicorn --chdir src/furigana-api --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app"
+startCommand = "python3 -m gunicorn --chdir src/furigana-api --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.11.0
+python-3.11


### PR DESCRIPTION
Update runtime.txt to specify python-3.11 instead of python-3.11.0 Modify all python commands to explicitly use python3 for consistency Add build command to railway configs and update nixpacks dependencies