### PR TITLE
fix(deployment): make build and startup paths flexible

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: cd src/furigana-api && gunicorn --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app
+web: bash -c 'if [ -d "src/furigana-api" ]; then cd src/furigana-api && gunicorn --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app; else cd furigana-api && gunicorn --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app; fi'

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,24 @@
 
 # Script de construcción para Railway
 
+echo "Directorio actual: $(pwd)"
+echo "Contenido del directorio:"
+ls -la
+
+# Detectar la ruta correcta al backend
+if [ -d "src/furigana-api" ]; then
+    BACKEND_DIR="src/furigana-api"
+elif [ -d "furigana-api" ]; then
+    BACKEND_DIR="furigana-api"
+else
+    echo "Buscando directorio furigana-api..."
+    find . -name "furigana-api" -type d
+    echo "ERROR: No se encontró el directorio furigana-api"
+    exit 1
+fi
+
+echo "Usando backend en: $BACKEND_DIR"
+
 echo "Instalando dependencias del sistema..."
 apt-get update
 apt-get install -y tesseract-ocr tesseract-ocr-jpn poppler-utils python3-pip
@@ -11,7 +29,11 @@ python3 -m ensurepip --upgrade
 python3 -m pip install --upgrade pip
 
 echo "Instalando dependencias de Python..."
-pip3 install -r src/furigana-api/requirements.txt
-pip3 install gunicorn
-
-echo "Build completado exitosamente"
+if [ -f "$BACKEND_DIR/requirements.txt" ]; then
+    pip3 install -r $BACKEND_DIR/requirements.txt
+    pip3 install gunicorn
+    echo "Dependencias instaladas exitosamente"
+else
+    echo "ERROR: No se encontró $BACKEND_DIR/requirements.txt"
+    exit 1
+fi

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -9,7 +9,7 @@ cmds = ["chmod +x build.sh && ./build.sh"]
 cmds = []
 
 [start]
-cmd = "cd src/furigana-api && gunicorn --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app"
+cmd = "bash -c 'if [ -d \"src/furigana-api\" ]; then cd src/furigana-api && gunicorn --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app; else cd furigana-api && gunicorn --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app; fi'"
 
 [variables]
 PYTHON_VERSION = "3.11"

--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "buildCommand": "chmod +x build.sh && ./build.sh"
   },
   "deploy": {
-    "startCommand": "cd src/furigana-api && gunicorn --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app",
+    "startCommand": "bash -c 'if [ -d \"src/furigana-api\" ]; then cd src/furigana-api && gunicorn --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app; else cd furigana-api && gunicorn --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app; fi'",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",

--- a/railway.toml
+++ b/railway.toml
@@ -4,7 +4,7 @@ builder = "NIXPACKS"
 buildCommand = "chmod +x build.sh && ./build.sh"
 
 [deploy]
-startCommand = "cd src/furigana-api && gunicorn --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app"
+startCommand = "bash -c 'if [ -d \"src/furigana-api\" ]; then cd src/furigana-api && gunicorn --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app; else cd furigana-api && gunicorn --bind 0.0.0.0:$PORT --workers 1 --timeout 120 app:app; fi'"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
Update deployment configurations to handle both src/furigana-api and furigana-api directory structures. The build script now detects the correct backend path and fails explicitly if not found. This ensures consistent deployment across different environments.